### PR TITLE
Add support for c++11 (i.e. for centos 7)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HOST_SYSTEM = $(shell uname | cut -f 1 -d_)
 SYSTEM ?= $(HOST_SYSTEM)
 CXX = g++
 CPPFLAGS += `pkg-config --cflags protobuf grpc`
-CXXFLAGS += -std=c++17 -DKALDI_DOUBLEPRECISION=0 -Wno-sign-compare -Wno-unused-local-typedefs \
+CXXFLAGS += -std=c++11 -DKALDI_DOUBLEPRECISION=0 -Wno-sign-compare -Wno-unused-local-typedefs \
 	-Wno-unused-variable -Winit-self -O3
 
 LDFLAGS += -L/usr/local/lib `pkg-config --libs protobuf grpc++` \

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -13,6 +13,47 @@
 // kaldi includes
 #include "base/kaldi-types.h"
 
+
+
+#if __cplusplus == 201103L
+  //make_unique() implementation for C++11 & 14 from https://stackoverflow.com/questions/17902405/how-to-implement-make-unique-function-in-c11/17902439#17902439
+  #include <cstddef>
+  #include <memory>
+  #include <type_traits>
+  #include <utility>
+
+  namespace std {
+    template<class T> struct _Unique_if {
+        typedef unique_ptr<T> _Single_object;
+    };
+
+    template<class T> struct _Unique_if<T[]> {
+        typedef unique_ptr<T[]> _Unknown_bound;
+    };
+
+    template<class T, size_t N> struct _Unique_if<T[N]> {
+        typedef void _Known_bound;
+    };
+
+    template<class T, class... Args>
+        typename _Unique_if<T>::_Single_object
+        make_unique(Args&&... args) {
+            return unique_ptr<T>(new T(std::forward<Args>(args)...));
+        }
+
+    template<class T>
+        typename _Unique_if<T>::_Unknown_bound
+        make_unique(size_t n) {
+            typedef typename remove_extent<T>::type U;
+            return unique_ptr<T>(new U[n]());
+        }
+
+    template<class T, class... Args>
+        typename _Unique_if<T>::_Known_bound
+        make_unique(Args&&...) = delete;
+  }
+#endif
+
 bool DEBUG = false;
 
 // Model Specification for Kaldi ASR


### PR DESCRIPTION
1) Add make_unique() function, which is the only missing piece to make kaldi-serve on c++11
2) switch -std=c++17 to -std=c++11 in Makefile