### PR TITLE
[grpc/scripts] Switch to Multithreading and Audio decoder error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ models.toml
 examples/*/model
 
 dev*
+
+.DS_Store
+.idea
+*.egg-info/
+*.pyc
+
+# pyenv
+python*-env
+.python-version

--- a/plugins/grpc/client/scripts/batch_decode.py
+++ b/plugins/grpc/client/scripts/batch_decode.py
@@ -35,7 +35,6 @@ client = KaldiServeClient()
 def run_multiprocessing(func, tasks, num_processes=None):
     with Pool(processes=num_processes) as pool:
         results = list(tqdm(pool.imap(func, tasks), total=len(tasks)))
-    pool.close()
     return results
 
 def run_multithreading(func, tasks, num_workers=None):
@@ -100,7 +99,7 @@ def decode_files(audio_paths: List[str], model: str, language_code: str,
                  sample_rate=8000, max_alternatives=10, raw: bool=False,
                  num_proc: int=8):
     """
-    Decode files using multiprocessing requests
+    Decode files using parallel requests
     """
     args = [
         (


### PR DESCRIPTION
This PR makes the following changes:

- `plugins/grpc/client/scripts/batch_decode.py`

    - simple error handing while loading audios
    - moving to multithreading since compute is handled by grpc server/docker
    - running multithreading with `tqdm` for active progress bar

- `.gitignore`
    - osx specific
    - ide specific
    - poetry specific artifacts