### PR TITLE
keep kaldi-serve from crashing if an expected model is not found

### DIFF
--- a/plugins/grpc/src/server.hpp
+++ b/plugins/grpc/src/server.hpp
@@ -104,7 +104,13 @@ class KaldiServeImpl final : public kaldi_serve::KaldiServe::Service {
 KaldiServeImpl::KaldiServeImpl(const std::vector<ModelSpec> &model_specs) noexcept {
     for (auto const &model_spec : model_specs) {
         model_id_t model_id = std::make_pair(model_spec.name, model_spec.language_code);
-        decoder_queue_map_[model_id] = std::unique_ptr<DecoderQueue>(new DecoderQueue(model_spec));
+        try {
+            decoder_queue_map_[model_id] = std::unique_ptr<DecoderQueue>(new DecoderQueue(model_spec));;
+        } catch (const std::runtime_error &e) {
+            // Expected while creation of ChainModel. Eg- when kaldi model is missing.
+            // This catch keeps kaldi-serve from exiting due to this error.
+            // Do nothing here. `decoder_queue_map_` will simply not contain an entry for key `model_id`.
+        }
     }
 }
 

--- a/plugins/grpc/src/server.hpp
+++ b/plugins/grpc/src/server.hpp
@@ -107,6 +107,7 @@ KaldiServeImpl::KaldiServeImpl(const std::vector<ModelSpec> &model_specs) noexce
         try {
             decoder_queue_map_[model_id] = std::unique_ptr<DecoderQueue>(new DecoderQueue(model_spec));;
         } catch (const std::runtime_error &e) {
+            std::cerr<<"Model not loaded: ("<<model_id.first<<","<<model_id.second<<"). This raised an error:"<<e.what()<<"\n";
             // Expected while creation of ChainModel. Eg- when kaldi model is missing.
             // This catch keeps kaldi-serve from exiting due to this error.
             // Do nothing here. `decoder_queue_map_` will simply not contain an entry for key `model_id`.


### PR DESCRIPTION
With this change, kaldi serve is expected to not crash due to model not found at specified path during ChainModel creation.

Old behaviour:
1. If a model is not found, `KALDI_ERR` macro is used to log error.
2. `KALDI_ERR` will print to STDERR and raise a `std::runtime_error`.
3. This uncaught `std::runtime_error` will lead to program exit.

New behaviour:
1. If a model is not found, `KALDI_ERR` macro is used to log error.
2. `KALDI_ERR` will print to STDERR and raise a `std::runtime_error`.
3. This `std::runtime_error` is caught, and entry for the model is not created in the `DecoderQueue` map.